### PR TITLE
Potential fix for code scanning alert no. 4: Clear text storage of sensitive information

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 // AuthContext.tsx
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import CryptoJS from 'crypto-js';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/lib/supabaseClient';
@@ -14,7 +15,6 @@ export interface User {
   address?: string;
 }
 
-interface AuthContextType {
   user: User | null;
   login: (email: string, password: string) => Promise<boolean>;
   logout: () => Promise<void>;
@@ -82,7 +82,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     };
 
     setUser(fullUser);
-    localStorage.setItem('forensicLedgerUser', JSON.stringify(fullUser));
+    localStorage.setItem('forensicLedgerUser', encryptData(JSON.stringify(fullUser)));
     return fullUser;
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/aaravmahajanofficial/forensic-ledger-guardian/security/code-scanning/4](https://github.com/aaravmahajanofficial/forensic-ledger-guardian/security/code-scanning/4)

To fix the problem, we should ensure that any sensitive information stored in localStorage is encrypted. The best way to do this is to encrypt the user profile object before storing it, and decrypt it when reading it back. We can use a well-known library such as `crypto-js` for symmetric encryption in the browser. The encryption key should not be hardcoded; ideally, it should be derived from a user secret (such as the session token or a hash of the user's password), but for this context, we can use a session-specific value (e.g., the Supabase access token) if available. The changes should be made in the `loadUserProfile` function, where the user profile is stored, and in any place where it is read back (though the provided code only shows storage).

**Required changes:**
- Add an import for `crypto-js`.
- Add utility functions for encrypting and decrypting data.
- Encrypt the user profile before storing it in localStorage.
- (Optionally) update any code that reads from localStorage to decrypt the data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
