### PR TITLE
Fix: Add loading state to auth flow

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -7,7 +7,11 @@ interface ProtectedRouteProps {
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <div>Loading...</div>; // Or a spinner component
+  }
 
   if (!isLoggedIn) {
     return <Navigate to="/" />;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -26,6 +26,7 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<boolean>;
   logout: () => Promise<void>;
   isLoggedIn: boolean;
+  isLoading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -35,24 +36,38 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const navigate = useNavigate();
   const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
 
   // DEV MODE: auto-login as officer
   useEffect(() => {
     if (import.meta.env.MODE === "development") {
-      import("./devAuth").then(({ DEV_OFFICER_USER }) => {
-        setUser(DEV_OFFICER_USER);
-        localStorage.setItem(
-          "forensicLedgerUser",
-          JSON.stringify(DEV_OFFICER_USER)
-        );
-      });
+      const localUser = localStorage.getItem("forensicLedgerUser");
+      if (localUser) {
+        setUser(JSON.parse(localUser));
+      } else {
+        import("./devAuth").then(({ DEV_OFFICER_USER }) => {
+          setUser(DEV_OFFICER_USER);
+          localStorage.setItem(
+            "forensicLedgerUser",
+            JSON.stringify(DEV_OFFICER_USER)
+          );
+        });
+      }
     }
   }, []);
 
   console.log("AuthProvider initialized");
 
   const login = async (email: string, password: string): Promise<boolean> => {
+    if (!supabase) {
+      toast({
+        title: "Application Not Configured",
+        description: "Supabase environment variables are missing.",
+        variant: "destructive",
+      });
+      return false;
+    }
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
@@ -97,6 +112,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
   const loadUserProfile = React.useCallback(
     async (userId: string, email: string) => {
+      if (!supabase) return null;
       const { data, error } = await supabase
         .from("profiles")
         .select("name, role, role_title, address")
@@ -125,7 +141,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   );
 
   useEffect(() => {
-    if (import.meta.env.MODE === "development") return;
+    if (import.meta.env.MODE === "development" || !supabase) {
+      setIsLoading(false);
+      return;
+    }
     const initAuth = async () => {
       const { data } = await supabase.auth.getSession();
       console.log("Loading user profile:", { data });
@@ -135,6 +154,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
           data.session.user.email || ""
         );
       }
+      setIsLoading(false);
     };
 
     initAuth();
@@ -156,6 +176,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   }, [loadUserProfile]);
 
   const logout = async () => {
+    if (!supabase) return;
     await supabase.auth.signOut();
     setUser(null);
     localStorage.removeItem("forensicLedgerUser");
@@ -167,7 +188,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, isLoggedIn: !!user }}>
+    <AuthContext.Provider value={{ user, login, logout, isLoggedIn: !!user, isLoading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('Supabase URL or Anon Key is missing. Make sure to set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your .env file.');
+}
+
+export const supabase = supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;


### PR DESCRIPTION
This commit addresses an issue where the user would get stuck on the login page on Vercel deployments. This was likely due to a race condition where the application would attempt to render a protected route before the user's authentication status had been determined.

The following changes have been made:

- `src/contexts/AuthContext.tsx`: An `isLoading` state has been added to the `AuthContext`. This state is used to track whether the initial authentication check is complete. The `AuthProvider` now provides this state to its children.

- `src/components/auth/ProtectedRoute.tsx`: The `ProtectedRoute` now checks the `isLoading` state. If the authentication check is in progress, it displays a loading indicator instead of redirecting the user to the login page.

- `src/lib/supabaseClient.ts`: The Supabase client is now initialized conditionally. If the `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` environment variables are not set, the `supabase` object will be `null`, and an error will be logged to the console.

- `src/contexts/AuthContext.tsx`: Checks have been added to the `login`, `logout`, `loadUserProfile`, and `useEffect` hooks to ensure that the `supabase` object is not `null` before attempting to use it. If the `supabase` object is `null`, a toast notification is displayed to the user, informing them that the application is not configured correctly.