### PR TITLE
Potential fix for code scanning alert no. 11: Server-side request forgery

### DIFF
--- a/ipfs-backend/package.json
+++ b/ipfs-backend/package.json
@@ -18,6 +18,7 @@
     "ethers": "^6.15.0",
     "express": "^5.1.0",
     "form-data": "^4.0.4",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "multiformats": "^13.4.0"
   }
 }

--- a/ipfs-backend/server.js
+++ b/ipfs-backend/server.js
@@ -1,6 +1,7 @@
 import express from "express";
 import multer from "multer";
 import axios from "axios";
+import { CID } from "multiformats/cid";
 import dotenv from "dotenv";
 import FormData from "form-data";
 
@@ -51,6 +52,14 @@ app.post("/upload", upload.single("file"), async (req, res) => {
 app.get("/retrieve/:cid", async (req, res) => {
   const { cid } = req.params;
   try {
+    // Validate that 'cid' is a valid IPFS CID.
+    let parsedCID;
+    try {
+      parsedCID = CID.parse(cid);
+    } catch (e) {
+      return res.status(400).json({ error: "Invalid CID format." });
+    }
+
     const url = `https://gateway.pinata.cloud/ipfs/${cid}`; 
     const response = await axios.get(url, { responseType: "arraybuffer" });
 


### PR DESCRIPTION
Potential fix for [https://github.com/aaravmahajanofficial/forensic-ledger-guardian/security/code-scanning/11](https://github.com/aaravmahajanofficial/forensic-ledger-guardian/security/code-scanning/11)

To eliminate the SSRF risk, the backend should validate the user-supplied `cid` parameter to ensure it matches the expected format of an IPFS CID before constructing the URL and making the remote request. This involves restricting the input to characters allowed in CIDs (e.g., base58 or base32 encoding), and rejecting the request if `cid` fails validation. The code to update is in the `/retrieve/:cid` route in `ipfs-backend/server.js`: validate `cid` right after reading it from `req.params`, and return a 400 error if it's invalid. For IPFS CIDs, a regex can be used to enforce allowed characters and length. Optionally, use a well-known package such as `multiformats/cid` to fully validate that input is a valid CID.

Required code additions:
- Install and import the `multiformats` package (`npm install multiformats`) for robust validation.
- Add validation logic before making the outgoing request.
- Return a 400 error if validation fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
