### PR TITLE
Potential fix for code scanning alert no. 11: Server-side request forgery

### DIFF
--- a/ipfs-backend/server.js
+++ b/ipfs-backend/server.js
@@ -60,9 +60,9 @@ app.get("/retrieve/:cid", async (req, res) => {
       return res.status(400).json({ error: "Invalid CID format." });
     }
 
-    const url = `https://gateway.pinata.cloud/ipfs/${cid}`; 
+    // Use only the validated, canonical CID string below:
+    const url = `https://gateway.pinata.cloud/ipfs/${parsedCID.toString()}`; 
     const response = await axios.get(url, { responseType: "arraybuffer" });
-
     
     res.setHeader("Content-Type", response.headers["content-type"]);
     res.send(response.data);


### PR DESCRIPTION
Potential fix for [https://github.com/aaravmahajanofficial/forensic-ledger-guardian/security/code-scanning/11](https://github.com/aaravmahajanofficial/forensic-ledger-guardian/security/code-scanning/11)

To fix the SSRF risk, further tighten validation for the `cid` parameter in `/retrieve/:cid`. While the `CID.parse` helps ensure input is a valid CID, make sure the outputted value does not contain path-traversal sequences, URI fragments, or special characters that could manipulate the constructed URL.  
- After parsing `cid`, ensure it is returned in canonical format via `CID.toString()`, never raw user-supplied string.
- Replace all uses of `cid` in the outbound request URL with the safely parsed/normalized value.
  
**Required changes:**
- On line 63, use `parsedCID.toString()` (never use the raw user-provided string).
- On lines 56–61, ensure that only a canonical CID string is used for constructing the URL.
- This change is localized to the `/retrieve/:cid` route in `ipfs-backend/server.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
