### PR TITLE
🔒 Security fix: Remove hardcoded Sepolia Private Key

### DIFF
--- a/ipfs-backend/backendfinal.js
+++ b/ipfs-backend/backendfinal.js
@@ -120,9 +120,11 @@ if (!PJWT) {
 const SRPC =
   process.env.SEPOLIA_RPC_URL ||
   "https://eth-sepolia.g.alchemy.com/v2/fg6YcFNolf21MTb_naEvF";
-const SPVT =
-  process.env.SEPOLIA_PRIVATE_KEY ||
-  "d87f8c49f3b3733f112a4565158abf591385b464679fc6c5f58c853e695cbfb7";
+const SPVT = process.env.SEPOLIA_PRIVATE_KEY;
+if (!SPVT) {
+  console.error("Critical: SEPOLIA_PRIVATE_KEY is not set.");
+  process.exit(1);
+}
 const CONTADD =
   process.env.CONTRACT_ADDRESS || "0x1e0e98b2bb9b4fabe7f497f8b609a319472a5758";
 const provider = new ethers.JsonRpcProvider(SRPC);


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded `SEPOLIA_PRIVATE_KEY` fallback string in `ipfs-backend/backendfinal.js`.
⚠️ **Risk:** Hardcoding private keys in source code is a critical vulnerability that allows anyone with access to the code to steal funds, compromise accounts, or manipulate on-chain interactions.
🛡️ **Solution:** The codebase now relies solely on the `process.env.SEPOLIA_PRIVATE_KEY` environment variable. A fast-fail mechanism is introduced, immediately exiting the process with a critical error message if the environment variable is not defined, adhering to security best practices and preventing the server from running in a compromised state.

---
*PR created automatically by Jules for task [5666959595291132596](https://jules.google.com/task/5666959595291132596) started by @aaravmahajanofficial*