### PR TITLE
🧹 Remove unused generateEvidenceId function

### DIFF
--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -21,13 +21,6 @@ export const getEvidenceTypeFromFile = (file: File): EvidenceType => {
   return EvidenceType.Other;
 };
 
-// Generate a unique evidence ID based on case and timestamp
-export const generateEvidenceId = (caseId: string): string => {
-  const timestamp = Date.now();
-  const randomPart = Math.random().toString(36).substring(2, 8);
-  return `EV-${caseId}-${timestamp}-${randomPart}`;
-};
-
 // Format date from blockchain timestamp
 export const formatBlockchainDate = (timestamp: number): string => {
   return new Date(timestamp * 1000).toLocaleString();


### PR DESCRIPTION
🎯 **What:** Removed the unused `generateEvidenceId` function from `src/utils/fileUtils.ts`.
💡 **Why:** This function was not used anywhere in the codebase. Removing dead code improves maintainability and readability.
✅ **Verification:** Verified by running `npm run lint` and `npm run build`, which both succeeded.
✨ **Result:** A cleaner codebase with less dead code.

---
*PR created automatically by Jules for task [15756678570360187405](https://jules.google.com/task/15756678570360187405) started by @aaravmahajanofficial*