### PR TITLE
🧹 Remove console.log from setGlobalRole in web3Service

### DIFF
--- a/src/services/web3Service.ts
+++ b/src/services/web3Service.ts
@@ -762,33 +762,16 @@ class Web3Service {
 
   public async setGlobalRole(user: string, role: Role): Promise<boolean> {
     if (!this.contract) {
-      console.log("setGlobalRole: No contract available");
       return false;
     }
 
     try {
-      console.log(
-        `setGlobalRole: Setting role ${this.getRoleString(
-          role
-        )} for user ${user}`
-      );
       const tx = await this.contract.setGlobalRole(user, role);
-      console.log(`setGlobalRole: Transaction sent, hash: ${tx.hash}`);
       await tx.wait();
-      console.log(
-        `setGlobalRole: Transaction confirmed for ${user} -> ${this.getRoleString(
-          role
-        )}`
-      );
 
       // Verify the role was set correctly
       const verifyRole = await this.contract.getGlobalRole(user);
       const verifiedRole = this.toNumber(verifyRole) as Role;
-      console.log(
-        `setGlobalRole: Verified role for ${user}: ${this.getRoleString(
-          verifiedRole
-        )}`
-      );
 
       return true;
     } catch (error) {


### PR DESCRIPTION
🎯 **What:** Removed `console.log` statements from the `setGlobalRole` function in `src/services/web3Service.ts`.
💡 **Why:** `console.log` statements are development remnants that can clutter up output and are not appropriate for production code. This improves the readability and code health of this service.
✅ **Verification:** Verified by checking the file, running `npm run build` and `npm run test` (which passes exactly as it did prior to changes, disregarding unrelated tests failing). 
✨ **Result:** Clean, production-ready `setGlobalRole` function.

---
*PR created automatically by Jules for task [4963691958016968433](https://jules.google.com/task/4963691958016968433) started by @aaravmahajanofficial*