### PR TITLE
ci: add autoupdate workflow for pull requests

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,0 +1,16 @@
+name: autoupdate
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatically update PRs
+        uses: docker://chinthakagodawita/autoupdate-action:v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_CONFLICT_ACTION: "ignore"

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Automatically update PRs
         uses: docker://chinthakagodawita/autoupdate-action:v1

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,4 +1,4 @@
-name: autoupdate
+name: Auto Update Pull Requests
 
 on:
   push:


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (`autoupdate.yml`) that automatically keeps open pull requests in sync with the `main` branch. 

It triggers on pushes to `main` and uses the `chinthakagodawita/autoupdate-action` to merge the latest changes from `main` into open PRs. The action is configured to silently ignore merge conflicts (`MERGE_CONFLICT_ACTION: "ignore"`), allowing the pre-existing `auto-comment-merge-conflicts.yml` workflow to handle notifying the user of conflicts when they arise.

---
*PR created automatically by Jules for task [14023680195646514559](https://jules.google.com/task/14023680195646514559) started by @aaravmahajanofficial*